### PR TITLE
Avoid error when importing assertions from std

### DIFF
--- a/src/plz.nim
+++ b/src/plz.nim
@@ -1,4 +1,4 @@
-import std/[strutils, json, os, httpclient, parseopt, terminal, logging, osproc, rdstdin, uri, browsers, assertions]
+import std/[strutils, json, os, httpclient, parseopt, terminal, logging, osproc, rdstdin, uri, browsers]
 import requirementstxt
 
 var

--- a/src/plz/docgen.nim
+++ b/src/plz/docgen.nim
@@ -1,4 +1,4 @@
-import std/[strtabs, assertions]
+import std/strtabs
 import packages/docutils/rst, packages/docutils/rstgen, packages/docutils/rstast
 
 

--- a/src/plz/dotenv.nim
+++ b/src/plz/dotenv.nim
@@ -1,7 +1,6 @@
 from std/json import JsonNode, newJInt, newJFloat, newJBool, newJString, newJObject, newJArray, add, parseJson
 from std/parseutils import parseSaturatedNatural, parseFloat
 from std/strutils import split
-import std/assertions
 
 template parseBool(s: string): bool = s == "true"
 

--- a/src/plz/pypiapi.nim
+++ b/src/plz/pypiapi.nim
@@ -1,4 +1,4 @@
-import std/[httpclient, strutils, xmlparser, xmltree, json, mimetypes, os, base64, times, osproc, rdstdin, md5, sha1, assertions]
+import std/[httpclient, strutils, xmlparser, xmltree, json, mimetypes, os, base64, times, osproc, rdstdin, md5, sha1]
 
 import requirementstxt
 

--- a/src/plz/pypinteract.nim
+++ b/src/plz/pypinteract.nim
@@ -1,4 +1,4 @@
-import std/[strutils, rdstdin, assertions]
+import std/[strutils, rdstdin]
 
 
 template uploadToPypi(file: string) {.used.} =

--- a/src/plz/utils.nim
+++ b/src/plz/utils.nim
@@ -1,4 +1,4 @@
-import std/[httpclient, os, osproc, terminal, rdstdin, times, random, browsers, sugar, strutils, uri, json, assertions]
+import std/[httpclient, os, osproc, terminal, rdstdin, times, random, browsers, sugar, strutils, uri, json]
 import sysinfo
 
 


### PR DESCRIPTION
```bash
$ nimble build
  Verifying dependencies for plz@0.0.1
   Building plz/plz using c backend
/Users/kunitoki/nim/plz/src/plz/pypiapi.nim(1, 11) Error: cannot open file: std/assertions
       Tip: 1 messages have been suppressed, use --verbose to show them.
     Error: Build failed for package: plz
        ... Execution failed with exit code 256
        ... Command: /Users/kunitoki/.nimble/bin/nim c --colors:on --noNimblePath -d:NimblePkgVersion=0.0.1 --hints:off -o:/Users/kunitoki/nim/plz/plz /Users/kunitoki/nim/plz/src/plz.nim
```